### PR TITLE
Implement `OpIEqual` and `OpINotEqual` in `Evaluator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,7 +243,7 @@ dependencies = [
  "fnv",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 3.9.2",
  "spirq-core",
 ]
 
@@ -249,7 +258,7 @@ dependencies = [
  "fnv",
  "half",
  "num-traits",
- "ordered-float",
+ "ordered-float 3.9.2",
  "spirv",
 ]
 
@@ -280,7 +289,7 @@ dependencies = [
  "fnv",
  "half",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.2.1",
  "spirv",
 ]
 

--- a/spq-core/Cargo.toml
+++ b/spq-core/Cargo.toml
@@ -21,7 +21,7 @@ maintenance = { status = "actively-developed" }
 fnv = "1.0.7"
 spirv = "0.3"
 anyhow = "1.0"
-ordered-float = "3.4"
+ordered-float = "4.2"
 num-traits = "0.2"
 half = { version = "2.3", features = ["num-traits"] }
 bytemuck = "1.14"

--- a/spq-core/src/evaluator.rs
+++ b/spq-core/src/evaluator.rs
@@ -599,6 +599,32 @@ impl Evaluator {
                     _ => return Err(evaluation_failed(op, result_ty, operands)),
                 }
             }
+            Op::IEqual => {
+                let (a, b) = match operands {
+                    [ConstantValue::S32(x), ConstantValue::S32(y)] => (*x as u64, *y as u64),
+                    [ConstantValue::S32(x), ConstantValue::U32(y)] => (*x as u64, *y as u64),
+                    [ConstantValue::U32(x), ConstantValue::S32(y)] => (*x as u64, *y as u64),
+                    [ConstantValue::U32(x), ConstantValue::U32(y)] => (*x as u64, *y as u64),
+                    _ => return Err(evaluation_failed(op, result_ty, operands)),
+                };
+                match result_ty {
+                    Type::Scalar(ScalarType::Boolean) => ConstantValue::Bool(a == b),
+                    _ => return Err(evaluation_failed(op, result_ty, operands)),
+                }
+            }
+            Op::INotEqual => {
+                let (a, b) = match operands {
+                    [ConstantValue::S32(x), ConstantValue::S32(y)] => (*x as u64, *y as u64),
+                    [ConstantValue::S32(x), ConstantValue::U32(y)] => (*x as u64, *y as u64),
+                    [ConstantValue::U32(x), ConstantValue::S32(y)] => (*x as u64, *y as u64),
+                    [ConstantValue::U32(x), ConstantValue::U32(y)] => (*x as u64, *y as u64),
+                    _ => return Err(evaluation_failed(op, result_ty, operands)),
+                };
+                match result_ty {
+                    Type::Scalar(ScalarType::Boolean) => ConstantValue::Bool(a != b),
+                    _ => return Err(evaluation_failed(op, result_ty, operands)),
+                }
+            }
             _ => return Err(evaluation_failed(op, result_ty, operands)),
         };
         Ok(value)


### PR DESCRIPTION
I've some shader code like this:

```hlsl
static const bool _SomeBool = (SomeConst == 0);
```

Which cannot be parsed by spirq.

Also spq-core is using an old version of ordered-float, which is different from spirq.