### PR TITLE
Fix for 16 bit spec const values

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+reorder_imports = false

--- a/spq-core/src/constant.rs
+++ b/spq-core/src/constant.rs
@@ -81,62 +81,62 @@ impl ConstantValue {
             match scalar_ty {
                 ScalarType::Boolean => Ok(ConstantValue::Bool(x.iter().any(|x| x != &0))),
                 ScalarType::Integer {
-                    bits: 8,
+                    bits: i8::BITS,
                     is_signed: true,
-                } if x.len() == 4 => {
+                } if matches!(x.len(), 1 | 4) => {
                     let x = i8::from_le_bytes([x[0]]);
                     Ok(ConstantValue::S8(x))
                 }
                 ScalarType::Integer {
-                    bits: 8,
+                    bits: u8::BITS,
                     is_signed: false,
-                } if x.len() == 4 => {
+                } if matches!(x.len(), 1 | 4) => {
                     let x = u8::from_le_bytes([x[0]]);
                     Ok(ConstantValue::U8(x))
                 }
                 ScalarType::Integer {
-                    bits: 16,
+                    bits: i16::BITS,
                     is_signed: true,
-                } if x.len() == 4 => {
+                } if matches!(x.len(), 2 | 4) => {
                     let x = i16::from_le_bytes([x[0], x[1]]);
                     Ok(ConstantValue::S16(x))
                 }
                 ScalarType::Integer {
-                    bits: 16,
+                    bits: u16::BITS,
                     is_signed: false,
-                } if x.len() == 4 => {
+                } if matches!(x.len(), 2 | 4) => {
                     let x = u16::from_le_bytes([x[0], x[1]]);
                     Ok(ConstantValue::U16(x))
                 }
                 ScalarType::Integer {
-                    bits: 32,
+                    bits: i32::BITS,
                     is_signed: true,
                 } if x.len() == 4 => {
                     let x = i32::from_le_bytes([x[0], x[1], x[2], x[3]]);
                     Ok(ConstantValue::S32(x))
                 }
                 ScalarType::Integer {
-                    bits: 32,
+                    bits: u32::BITS,
                     is_signed: false,
                 } if x.len() == 4 => {
                     let x = u32::from_le_bytes([x[0], x[1], x[2], x[3]]);
                     Ok(ConstantValue::U32(x))
                 }
                 ScalarType::Integer {
-                    bits: 64,
+                    bits: i64::BITS,
                     is_signed: true,
                 } if x.len() == 8 => {
                     let x = i64::from_le_bytes([x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]]);
                     Ok(ConstantValue::S64(x))
                 }
                 ScalarType::Integer {
-                    bits: 64,
+                    bits: u64::BITS,
                     is_signed: false,
                 } if x.len() == 8 => {
                     let x = u64::from_le_bytes([x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]]);
                     Ok(ConstantValue::U64(x))
                 }
-                ScalarType::Float { bits: 16 } if x.len() == 4 => {
+                ScalarType::Float { bits: 16 } if matches!(x.len(), 2 | 4) => {
                     let x = f16::from_le_bytes([x[0], x[1]]);
                     Ok(ConstantValue::F16(OrderedFloat(x)))
                 }

--- a/spq-core/src/evaluator.rs
+++ b/spq-core/src/evaluator.rs
@@ -126,27 +126,57 @@ impl Evaluator {
             }
             Op::SConvert => {
                 let x = match operands {
-                    [ConstantValue::S32(x)] => *x,
+                    [ConstantValue::S8(x)] => *x as _,
+                    [ConstantValue::S16(x)] => *x as _,
+                    [ConstantValue::S32(x)] => *x as _,
+                    [ConstantValue::S64(x)] => *x,
                     _ => return Err(evaluation_failed(op, result_ty, operands)),
                 };
                 match result_ty {
                     Type::Scalar(ScalarType::Integer {
+                        bits: 8,
+                        is_signed: true,
+                    }) => ConstantValue::S8(x as _),
+                    Type::Scalar(ScalarType::Integer {
+                        bits: 16,
+                        is_signed: true,
+                    }) => ConstantValue::S16(x as _),
+                    Type::Scalar(ScalarType::Integer {
                         bits: 32,
                         is_signed: true,
-                    }) => ConstantValue::S32(x),
+                    }) => ConstantValue::S32(x as _),
+                    Type::Scalar(ScalarType::Integer {
+                        bits: 64,
+                        is_signed: true,
+                    }) => ConstantValue::S64(x),
                     _ => return Err(evaluation_failed(op, result_ty, operands)),
                 }
             }
             Op::UConvert => {
                 let x = match operands {
-                    [ConstantValue::U32(x)] => *x,
+                    [ConstantValue::U8(x)] => *x as _,
+                    [ConstantValue::U16(x)] => *x as _,
+                    [ConstantValue::U32(x)] => *x as _,
+                    [ConstantValue::U64(x)] => *x,
                     _ => return Err(evaluation_failed(op, result_ty, operands)),
                 };
                 match result_ty {
                     Type::Scalar(ScalarType::Integer {
+                        bits: 8,
+                        is_signed: false,
+                    }) => ConstantValue::U8(x as _),
+                    Type::Scalar(ScalarType::Integer {
+                        bits: 16,
+                        is_signed: false,
+                    }) => ConstantValue::U16(x as _),
+                    Type::Scalar(ScalarType::Integer {
                         bits: 32,
                         is_signed: false,
-                    }) => ConstantValue::U32(x),
+                    }) => ConstantValue::U32(x as _),
+                    Type::Scalar(ScalarType::Integer {
+                        bits: 64,
+                        is_signed: false,
+                    }) => ConstantValue::U64(x),
                     _ => return Err(evaluation_failed(op, result_ty, operands)),
                 }
             }

--- a/spq-spvasm/src/asm/tokenizer.rs
+++ b/spq-spvasm/src/asm/tokenizer.rs
@@ -15,6 +15,7 @@ pub enum Lit {
 
 #[derive(Debug)]
 pub enum Token {
+    #[allow(dead_code)]
     Comment(String),
     Literal(Lit),
     Ident(String),


### PR DESCRIPTION
I ran into two issues using `u16` specialized constants:
- `spirq::reflect_cfg::ReflectConfig::specialize()` allows using two bytes to setup a typeless constant, but `spq_core::constant::ConstantValue::to_typed()` expected four-byte `u32`-encoded constants
- Some op code evaluator implementations were missing

As far as the evaluator implementations, there are a bunch of missing cases (see #1). I think reorganizing them into something like `match (op, operands, result_ty) { ...` might make the code easier to fill out and remove a bunch of duplicated `Err` cases.